### PR TITLE
Wrong header etag is fixed to if-match.

### DIFF
--- a/kii.c
+++ b/kii.c
@@ -163,7 +163,7 @@ prv_http_request(
     if (etag != NULL) {
         result = kii->http_set_header_cb(
                 kii->http_context,
-                "etag",
+                "if-match",
                 etag 
                 );
         if (result != KII_HTTPC_OK) {


### PR DESCRIPTION
送信用のHTTPヘッダで使われているetagはif-matchの間違いだったので修正しました。

関連issuse #17
