### PR TITLE
HTTP message buffer size are initialized at PRV_STATE_IDLE.

### DIFF
--- a/gt202/gt202_kii_adapter.c
+++ b/gt202/gt202_kii_adapter.c
@@ -214,6 +214,9 @@ kii_http_client_code_t
     kii_http_client_code_t res;
     switch (ctx->state) {
         case PRV_STATE_IDLE:
+            ctx->sent_size = 0;
+            ctx->last_chunk = 0;
+            ctx->received_size = 0;
             ctx->state = PRV_STATE_CONNECT;
             return KII_HTTPC_AGAIN;
         case PRV_STATE_CONNECT:


### PR DESCRIPTION
同じcontextを一回の実行で複数回利用出来るよう、IDLE状態からCONNECT状態へ移行する際にバッファのサイズを初期化するように修正しました。
