### PR TITLE
KII_PUSH_RECEIVED_CB is removed.

### DIFF
--- a/kii_core.h
+++ b/kii_core.h
@@ -128,8 +128,6 @@ typedef void
                 ...
                 );
 
-typedef void (*KII_PUSH_RECEIVED_CB)(char* message, size_t message_length);
-
 /** error code returned by SDK apis. */
 typedef enum kii_error_code_t {
     KIIE_OK = 0,


### PR DESCRIPTION
KII_PUSH_RECEIVED_CB is removed according to discussion on KiiCorp/IoTCloud#7
