### PR TITLE
Part of #39 is rollbacked.

### DIFF
--- a/kii_core.c
+++ b/kii_core.c
@@ -770,6 +770,7 @@ kii_core_api_call(
         const char* http_method,
         const char* resource_path,
         const char* http_body,
+        size_t body_size,
         const char* content_type,
         char* header,
         ...)
@@ -892,7 +893,7 @@ kii_core_api_call(
     if (http_body != NULL) {
         char content_length[8];
         kii_memset(content_length, 0x00, 8);
-        prv_content_length_str(strlen(http_body), content_length, 8);
+        prv_content_length_str(body_size, content_length, 8);
         result = kii->http_set_header_cb(
                 &(kii->http_context),
                 "content-length",
@@ -902,15 +903,15 @@ kii_core_api_call(
             M_KII_LOG(M_REQUEST_LINE_CB_FAILED);
             goto exit;
         }
-
-        result = kii->http_set_body_cb(&(kii->http_context), http_body);
-        if (result != KII_HTTPC_OK) {
+        strcat(kii->http_context.buffer, "\r\n");
+        kii->http_context.total_send_size = strlen(kii->http_context.buffer);
+	if ((kii->http_context.total_send_size + body_size) > kii->http_context.buffer_size) {
             M_KII_LOG(M_REQUEST_BODY_CB_FAILED);
-            return KIIE_FAIL;
-        } else {
-            kii->http_context.total_send_size = strlen(
-                    kii->http_context.buffer);
-        }
+            goto exit;
+	} else {
+		kii->http_context.total_send_size +=body_size;
+		memcpy(kii->http_context.buffer + strlen(kii->http_context.buffer), http_body, body_size);
+	}
     } else {
         result = kii->http_set_body_cb(
                 &(kii->http_context),

--- a/kii_core.h
+++ b/kii_core.h
@@ -94,7 +94,6 @@ typedef kii_http_client_code_t
  * do not return KII_HTTPC_AGAIN from this callback.
  * @param [in] http_context context object defined by application.
  * @param [in] body_data request body data.
- * This data is null-terminated byte string.
  */
 typedef kii_http_client_code_t
         (*KII_HTTPCB_SET_BODY)(
@@ -502,7 +501,7 @@ kii_core_get_mqtt_endpoint(kii_core_t* kii,
  * @param [in] http_method method of http request.
  * @param [in] resource_path resource path of http request.
  * @param [in] http_body body data of http request.
- * This must be null-terminated byte string.
+ * @param [in] body_size size of http_body.
  * @param [in] content_type content type of http_body.
  * @param [in] header append headers of http request.
  * one header value like "{key}:{value}".
@@ -513,6 +512,7 @@ kii_core_api_call(
         const char* http_method,
         const char* resource_path,
         const char* http_body,
+        size_t body_size,
         const char* content_type,
         char* header,
         ...);

--- a/linux/example.c
+++ b/linux/example.c
@@ -1011,7 +1011,7 @@ int main(int argc, char** argv)
             break;
         case 16:
             printf("api\n");
-            kii_core_api_call(&kii, "GET", "hoge/fuga", "body", "text/plain",
+            kii_core_api_call(&kii, "GET", "hoge/fuga", "body", 4, "text/plain",
                     "x-kii-http-header1:value", "x-kii-http-header2:value2", NULL);
             print_request(&kii);
             break;


### PR DESCRIPTION
#41 の `KII_HTTPCB_SET_BODY` の作業を行う前に、実装を #39 の修正の一部をロールバックしました。

API的には #39 の前の物になります。 #41 での話し合いの結果、 `kii_core_api_call` はhttp_bodyの長さを渡す形になるのでそのようになっています。
#39 では必要なドキュメントの修正や、より良い動作への変更などを伴っていたのでその部分はロールバックせずに残してあります。
