### PR TITLE
Request message for kii_core_api_call is logged.

### DIFF
--- a/kii_core.c
+++ b/kii_core.c
@@ -1552,6 +1552,8 @@ kii_error_code_t kii_core_api_call_end(kii_core_t* kii)
         return KIIE_FAIL;
     }
 
+    M_KII_LOG_FORMAT(kii->logger_cb("request: %s\n", kii->http_context.buffer));
+
     // set reday.
     if (kii->_state != KII_STATE_IDLE) {
         return KIIE_FAIL;


### PR DESCRIPTION
KiiCorp/IoTCloud#30 のコメントで、ログをkii-coreレベルで出そうという事になりましたので、修正しました。
